### PR TITLE
✨ UPDATE: Remove pull request trigger from build workflow for main an…

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -3,8 +3,6 @@ name: Build SushiScan Apps
 on:
   push:
     branches: [ main, master ]
-  pull_request:
-    branches: [ main, master ]
 
 permissions:
   contents: write  # Allows uploading artifacts and creating releases


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for building SushiScan desktop applications. The change removes the trigger for the workflow to run on pull requests targeting the `main` or `master` branches.

* [`.github/workflows/build-desktop.yml`](diffhunk://#diff-ef3038449c722513ab596d849b3260c6bb16d207e9354c1760c11fb7d86b0258L6-L7): Removed the `pull_request` trigger from the workflow configuration, limiting its execution to `push` events on the `main` and `master` branches.…d master branches