### PR TITLE
✨ UPDATE: Enable code trimming for Android APK publishing in build wo…

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -105,7 +105,7 @@ jobs:
         dotnet restore SushiScan.Android/SushiScan.Android.csproj
       
     - name: Publish Android APK
-      run: dotnet publish SushiScan.Android/SushiScan.Android.csproj -c Release -r android-arm64 --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true -p:AndroidUseAapt2=true -o ./publish/android
+      run: dotnet publish SushiScan.Android/SushiScan.Android.csproj -c Release -r android-arm64 --self-contained true -p:PublishSingleFile=false -p:AndroidUseAapt2=true -o ./publish/android
     - name: Rename signed APK
       run: |
         if [ -f "./publish/android/com.saumondeluxe.SushiScan-Signed.apk" ]; then


### PR DESCRIPTION
This pull request makes a minor adjustment to the Android APK publishing process in the GitHub Actions workflow. The change removes the `-p:PublishTrimmed=true` parameter from the `dotnet publish` command.

* [`.github/workflows/build-desktop.yml`](diffhunk://#diff-ef3038449c722513ab596d849b3260c6bb16d207e9354c1760c11fb7d86b0258L108-R108): Removed the `-p:PublishTrimmed=true` parameter from the Android APK publishing step, likely to address compatibility or build issues